### PR TITLE
Classifiers -> classification in hackage link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Hackage links:
 
 * [HLearn-algebra](http://hackage.haskell.org/package/HLearn-algebra)
 * [HLearn-distributions](http://hackage.haskell.org/package/HLearn-distributions)
-* [HLearn-classifiers](http://hackage.haskell.org/package/HLearn-classifiers)
+* [HLearn-classification](http://hackage.haskell.org/package/HLearn-classification)
 * [HLearn-markov](http://hackage.haskell.org/package/HLearn-markov)
 
 


### PR DESCRIPTION
HLearn-classifiers was not on hackage but HLearn-classification was so I changed the link to match what was on hackage.
