### PR TITLE
fix hs-source-dirs for test

### DIFF
--- a/HLearn.cabal
+++ b/HLearn.cabal
@@ -295,7 +295,7 @@ test-suite tests
       -Werror
 
   hs-source-dirs:
-      src/test
+      test
 
   main-is:
       Spec.hs


### PR DESCRIPTION
Project was unbuildable with tests because of a wrong path.