### PR TITLE
Changed cabal source module from HLern.Metrics.EMD to HLearn.Data.Image

### DIFF
--- a/hlearn.cabal
+++ b/hlearn.cabal
@@ -126,7 +126,7 @@ Library
 --         HLearn.Models.Classifiers.Perceptron
 --         HLearn.Models.Classifiers.Centroid
 
-        HLearn.Metrics.EMD
+        HLearn.Data.Image
 --         HLearn.Metrics.Mahalanobis
 --         HLearn.Metrics.Mahalanobis.ITML
 --         HLearn.Metrics.Mahalanobis.Lego


### PR DESCRIPTION
I needed to make this change to the cabal file to compile this package with some recent renaming of modules