### PR TITLE
Add cabal sandbox files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ dist/
 gitignore/
 examples/old/
 scripts/
+
+.cabal-sandbox/
+cabal.sandbox.config
+
+.stack-work/


### PR DESCRIPTION
I use cabal sandboxes to build HLearn, so it's nice to have `.cabal-sandbox/` and `cabal.sandbox.config` added to the `.gitignore` file.

I also added `.stack-work/` (which is similar to `.cabal-sandbox/` for `stack`) because eventually(?) someone will probably build this package with `stack`.